### PR TITLE
tabs组件不兼容触控板滑动修复

### DIFF
--- a/src/layout/Tabs/index.vue
+++ b/src/layout/Tabs/index.vue
@@ -198,9 +198,9 @@ export default defineComponent({
     function handleWhellScroll(e: any) {
       let distance = 0
       let speed = 5
-      if (e.wheelDelta > 0) {
+      if (e.wheelDelta > 30) {
         distance = -10
-      } else {
+      } else if (e.wheelDelta < -30) {
         distance = 10
       }
       // console.log(scrollLeft.value + eventDelta / 4)


### PR DESCRIPTION
滚动事件中获取到的 e.wheelDelta 在鼠标滑轮滚动时稳定为120，但是触控板滑动时是介于-10和10之间的。
导致触控板滑动时会出现tabs闪烁。

经过测试，限制当e.wheelDelta处于-30和30之间可以比较有效的解决问题